### PR TITLE
Fixing up an interesting condition

### DIFF
--- a/data/salt/states/base/scripts/config/root/scripts/docker-kill.sh
+++ b/data/salt/states/base/scripts/config/root/scripts/docker-kill.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+## Quick and dirty saolution to clean up containers for supervisor
+## Docker will restart containers but we want them to be managed by supervisor
+## so some manual clean up may be required
+
+## Get List of Container ID's
+CONTAINERS=$(/usr/bin/docker ps -a | grep latest | grep Exited | awk '{print $1}')
+
+## For each container id remove it
+for CID in $CONTAINERS
+do
+  /usr/bin/docker rm --force $CID
+done

--- a/data/salt/states/runbook/supervisor/config/etc/cron.d/docker-kill
+++ b/data/salt/states/runbook/supervisor/config/etc/cron.d/docker-kill
@@ -1,0 +1,1 @@
+* * * * * root /root/scripts/docker-kill.sh 2>&1 > /dev/null

--- a/data/salt/states/runbook/supervisor/init.sls
+++ b/data/salt/states/runbook/supervisor/init.sls
@@ -4,3 +4,10 @@ supervisor:
   service:
     - running
     - enable: True
+
+/etc/cron.d/docker-kill:
+  file.managed:
+    - source: salt://supervisor/config/etc/cron.d/docker-kill
+    - user: root
+    - group: root
+    - mode: 644


### PR DESCRIPTION
When running docker via supervisor if the docker.io service is restarted it messes up supervisord's ability to manage the container. So a simple solution is just clean them up.
